### PR TITLE
Add urllib3 Dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,9 @@ setup(
     author_email='ambika.sukla@nlmatics.com',
     license='MIT',
     packages=find_packages(),
-    install_requires=[],
+    install_requires=[
+        "urllib3"
+    ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Development Status :: 1 - Planning',


### PR DESCRIPTION
In a fresh environment where `urllib3` is not installed, the client will complain the library needs to be installed. Added to `install_requires` list in `setup.py`

Fixes #2 