### PR TITLE
Fixed two LlamaIndex imports

### DIFF
--- a/llmsherpa/examples/LayoutPDFReader_Demo.ipynb
+++ b/llmsherpa/examples/LayoutPDFReader_Demo.ipynb
@@ -408,8 +408,7 @@
     {
       "cell_type": "code",
       "source": [
-        "from llama_index.readers.schema.base import Document\n",
-        "from llama_index import VectorStoreIndex\n",
+        "from llama_index.core import Document, VectorStoreIndex\n",
         "\n",
         "index = VectorStoreIndex([])\n",
         "for chunk in doc.chunks():\n",


### PR DESCRIPTION
The official Colab notebook failed on the two updated LlamaIndex imports. The imports don't raise an exception anymore.

Note: I don't have an OpenAI API key, so I could not test the whole changed cell. I would be useful to test it.