### PR TITLE
Fixes Issue #79. Fixed repetition of text in to_text and to_html methods of the Document class

### DIFF
--- a/llmsherpa/readers/tests/test_layout_reader.py
+++ b/llmsherpa/readers/tests/test_layout_reader.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 from llmsherpa.readers import LayoutReader
+from llmsherpa.readers import Document
 
 
 class TestLayoutReader(unittest.TestCase):
@@ -19,6 +20,12 @@ class TestLayoutReader(unittest.TestCase):
             reader = LayoutReader()
             doc = reader.read(doc_data)
         # reader.debug(pdf)
+        return doc
+    
+    def get_document(self, file_name):
+        with open(os.path.join(os.path.dirname(__file__), file_name)) as f:
+            doc_data = json.load(f)
+            doc = Document(doc_data)
         return doc
 
     def test_list_child_of_header(self):
@@ -127,6 +134,18 @@ class TestLayoutReader(unittest.TestCase):
         self.assertEqual(chunks[0].block_idx, 112)
         self.assertEqual(chunks[0].top, 64.8)
         self.assertEqual(chunks[0].left, 130.05)
+
+    def test_to_text(self):
+        doc = self.get_document("to_text_test.json")
+        
+        correct_text = "Lecture notes\nCS229\nPart VI\n"
+        self.assertEqual(doc.to_text(), correct_text)
+    
+    def test_to_html(self):
+        doc = self.get_document("to_html_test.json")
+        
+        correct_html = "<html><h1>Heading 1</h1><h2>Heading 2</h2><h2>Heading 3</h2></html>"
+        self.assertEqual(doc.to_html(), correct_html)
 
 if __name__ == '__main__':
     unittest.main()

--- a/llmsherpa/readers/tests/to_html_test.json
+++ b/llmsherpa/readers/tests/to_html_test.json
@@ -1,0 +1,32 @@
+[
+    {
+        "block_class": "cls_0",
+        "block_idx": 0,
+        "level": 0,
+        "page_idx": 0,
+        "sentences": [
+            "Heading 1"
+        ],
+        "tag": "header"
+    },
+    {
+        "block_class": "cls_1",
+        "block_idx": 1,
+        "level": 1,
+        "page_idx": 0,
+        "sentences": [
+            "Heading 2"
+        ],
+        "tag": "header"
+    },
+    {
+        "block_class": "cls_2",
+        "block_idx": 2,
+        "level": 1,
+        "page_idx": 0,
+        "sentences": [
+            "Heading 3"
+        ],
+        "tag": "header"
+    }
+]

--- a/llmsherpa/readers/tests/to_text_test.json
+++ b/llmsherpa/readers/tests/to_text_test.json
@@ -1,0 +1,32 @@
+[
+    {
+        "block_class": "cls_0",
+        "block_idx": 0,
+        "level": 0,
+        "page_idx": 0,
+        "sentences": [
+            "Lecture notes"
+        ],
+        "tag": "header"
+    },
+    {
+        "block_class": "cls_1",
+        "block_idx": 1,
+        "level": 1,
+        "page_idx": 0,
+        "sentences": [
+            "CS229"
+        ],
+        "tag": "header"
+    },
+    {
+        "block_class": "cls_2",
+        "block_idx": 2,
+        "level": 1,
+        "page_idx": 0,
+        "sentences": [
+            "Part VI"
+        ],
+        "tag": "header"
+    }
+]


### PR DESCRIPTION
Fixes #79 

Here is the current implementation of the `to_text` method:
```python
def to_text(self):
    """
    Returns text of a document by iterating through all the sections '\n'
    """
    text = ""
    for section in self.sections():
        text = text + section.to_text(include_children=True, recurse=True) + "\n"
    return text
```
The issue occurs when the document tree has the following (or similar) structure:
```
Section-1
├── Section-2
├── Section-3
```

The text of `Section-2` is included in the output when the `to_text` method is called (recursively) for `Section-1` as well as for`Section-2`.
Similarly, the text of `Section-3` is also duplicated in the output.

To remove the duplicates, iterate over all the sections in the document and choose the top sections i.e., those sections which are not a children of any other section. At the end, concatenate the (recursive) text of all the top sections.

Here is a summary of the changes made:
- The method `_get_top_sections` returns all the top sections in the document tree.
- `to_text` and `to_html` methods accept a boolean parameter `include_duplicates`.
- If `include_duplicates` is `False`, only the top sections are considered.
- Otherwise, all the sections are considered.

You can take a look at this fix in **Google Colab** [here](https://colab.research.google.com/drive/1YatMfrkFxJYfB6Ohkml9PGhZTnTng3-i?usp=sharing).