### PR TITLE
Incorrect child assignment for 'header' blocks in LayoutReader.read

### DIFF
--- a/llmsherpa/readers/layout_reader.py
+++ b/llmsherpa/readers/layout_reader.py
@@ -489,8 +489,8 @@ class LayoutReader:
                     parent_stack.append(node)
                     parent.add_child(node)
                 else:
-                    while len(parent_stack) > 1 and parent_stack.pop().level > node.level:
-                        pass
+                    while len(parent_stack) > 1 and parent_stack[-1].level >= node.level:
+                        parent_stack.pop()
                     parent_stack[-1].add_child(node)            
                     parent_stack.append(node)
                 parent = node

--- a/llmsherpa/readers/tests/ooo_header_child_test.json
+++ b/llmsherpa/readers/tests/ooo_header_child_test.json
@@ -1,0 +1,102 @@
+[
+    {
+        "tag": "header",
+        "page_idx": 0,
+        "block_class": "cls_0",
+        "sentences": [
+            "Article I"
+        ],
+        "block_idx": 0,
+        "level": 0
+    },
+    {
+        "tag": "header",
+        "page_idx": 0,
+        "block_class": "cls_0",
+        "sentences": [
+            "Article II"
+        ],
+        "block_idx": 0,
+        "level": 0
+    },    
+    {
+        "tag": "header",
+        "page_idx": 0,
+        "block_class": "cls_0",
+        "sentences": [
+            "OutOfOrder Section 1"
+        ],
+        "block_idx": 0,
+        "level": 2
+    },
+    {
+        "tag": "header",
+        "page_idx": 0,
+        "block_class": "cls_0",
+        "sentences": [
+            "Section 2"
+        ],
+        "block_idx": 0,
+        "level": 1
+    },
+    {
+        "tag": "header",
+        "page_idx": 0,
+        "block_class": "cls_0",
+        "sentences": [
+            "2.1 Two point one"
+        ],
+        "block_idx": 0,
+        "level": 2
+    },
+    {
+        "tag": "header",
+        "page_idx": 0,
+        "block_class": "cls_0",
+        "sentences": [
+            "2.2 Two point two"
+        ],
+        "block_idx": 0,
+        "level": 2
+    },
+    {
+        "tag": "header",
+        "page_idx": 0,
+        "block_class": "cls_0",
+        "sentences": [
+            "Section 3"
+        ],
+        "block_idx": 0,
+        "level": 1
+    },
+    {
+        "tag": "header",
+        "page_idx": 0,
+        "block_class": "cls_0",
+        "sentences": [
+            "OutOfOrder Section 4"
+        ],
+        "block_idx": 0,
+        "level": 3
+    },
+    {
+        "tag": "header",
+        "page_idx": 0,
+        "block_class": "cls_0",
+        "sentences": [
+            "3.1 Three point one"
+        ],
+        "block_idx": 0,
+        "level": 2
+    },
+    {
+        "tag": "header",
+        "page_idx": 0,
+        "block_class": "cls_0",
+        "sentences": [
+            "3.2 Three point two"
+        ],
+        "block_idx": 0,
+        "level": 2
+    }
+]

--- a/llmsherpa/readers/tests/test_layout_reader.py
+++ b/llmsherpa/readers/tests/test_layout_reader.py
@@ -76,6 +76,16 @@ class TestLayoutReader(unittest.TestCase):
         self.assertEqual(len(doc.children[2].children[0].children),  2)
         self.assertEqual(len(doc.children[3].children[0].children[1].children),  2)
         self.assertEqual(doc.children[3].children[0].children[1].parent_text(), "Article II > Section 1")
+
+    def test_ooo_nested_header_children(self):
+        # OutOfOrder Header children test case
+        doc = self.read_layout("ooo_header_child_test.json")
+        self.assertEqual(len(doc.children[0].children),  0)
+        self.assertEqual(len(doc.children[1].children),  3)
+        self.assertEqual(len(doc.children[1].children[0].children),  0)
+        self.assertEqual(len(doc.children[1].children[1].children),  2)
+        self.assertEqual(len(doc.children[1].children[2].children),  3)
+        self.assertEqual(len(doc.children[1].children[2].children[0].children),  0)
     
     def test_table(self):
         doc = self.read_layout("table_test.json")


### PR DESCRIPTION
Fixed parent-child assignment for 'header' blocks when the appearance order of blocks doesn't follow the logical level sequence (e.g. header level 0, header level 2, header level 1, ...)